### PR TITLE
feat: created the TransitionAfterContinous transition class

### DIFF
--- a/src/Transitions/TransitionAfterContinuous.cs
+++ b/src/Transitions/TransitionAfterContinuous.cs
@@ -1,0 +1,90 @@
+using System;
+
+namespace UnityHFSM
+{
+	/// <summary>
+	/// A class used to determine whether the state machine should transition to another state.
+	/// The transition will occur only when the condition remains true for a predefined period of time, determined by delay.
+	/// </summary>
+	public class TransitionAfterContinuous<TStateId> : TransitionBase<TStateId>
+	{
+		public float delay;
+		public ITimer timer;
+
+		public Func<TransitionAfterContinuous<TStateId>, bool> condition;
+
+		public Action<TransitionAfterContinuous<TStateId>> beforeTransition;
+		public Action<TransitionAfterContinuous<TStateId>> afterTransition;
+
+		/// <summary>
+		/// Initialises a new instance of the TransitionAfterContinuous class.
+		/// </summary>
+		/// <param name="delay">The amount of time that must elapse with the <c>to</c> being true for the transition to <c>to</c> happen </param>
+		/// <param name="condition">A function that returns true if the state machine
+		/// 	should transition to the <c>to</c> state.
+		/// 	It is only called every frame, but the transition will occur only if the condition is true for the amount of continuous amount of time, determined by <c>delay</c> .</param>
+		/// <inheritdoc cref="Transition{TStateId}(TStateId, TStateId, Func{Transition{TStateId}, bool},
+		/// 	Action{Transition{TStateId}}, Action{Transition{TStateId}}, bool)" />
+		public TransitionAfterContinuous(
+				TStateId from,
+				TStateId to,
+				float delay,
+				Func<TransitionAfterContinuous<TStateId>, bool> condition = null,
+				Action<TransitionAfterContinuous<TStateId>> onTransition = null,
+				Action<TransitionAfterContinuous<TStateId>> afterTransition = null,
+				bool forceInstantly = false) : base(from, to, forceInstantly)
+		{
+			this.delay = delay;
+			this.condition = condition;
+			this.beforeTransition = onTransition;
+			this.afterTransition = afterTransition;
+			this.timer = new Timer();
+		}
+
+		public override void OnEnter()
+		{
+			timer.Reset();
+		}
+
+		public override bool ShouldTransition()
+		{
+			// if no condition is provided, the state will auto transition after the delay amount of time
+			if (condition == null)
+				return timer.Elapsed > delay;
+
+			// if a condition is provided, it will be tested every frame, and the transition should occur when delay amount of time has elapsed
+			if (condition(this))
+				return timer.Elapsed > delay;
+
+			// if the condition is false, the timer will reset, restarting the whole process
+			timer.Reset();
+			return false;
+		}
+
+		public override void BeforeTransition() => beforeTransition?.Invoke(this);
+		public override void AfterTransition() => afterTransition?.Invoke(this);
+	}
+
+	/// <inheritdoc />
+	public class TransitionAfterContinuous : TransitionAfterContinuous<string>
+	{
+		/// <inheritdoc />
+		public TransitionAfterContinuous(
+			string @from,
+			string to,
+			float delay,
+			Func<TransitionAfterContinuous<string>, bool> condition = null,
+			Action<TransitionAfterContinuous<string>> onTransition = null,
+			Action<TransitionAfterContinuous<string>> afterTransition = null,
+			bool forceInstantly = false) : base(
+				@from,
+				to,
+				delay,
+				condition,
+				onTransition: onTransition,
+				afterTransition: afterTransition,
+				forceInstantly: forceInstantly)
+		{
+		}
+	}
+}

--- a/src/Transitions/TransitionAfterContinuous.cs
+++ b/src/Transitions/TransitionAfterContinuous.cs
@@ -4,11 +4,11 @@ namespace UnityHFSM
 {
 	/// <summary>
 	/// A class used to determine whether the state machine should transition to another state.
-	/// The transition will occur only when the condition remains true for a predefined period of time, determined by delay.
+	/// The transition will occur only when the condition remains true for a predefined period of time, determined by conditionTotalTime.
 	/// </summary>
 	public class TransitionAfterContinuous<TStateId> : TransitionBase<TStateId>
 	{
-		public float delay;
+		public float conditionTotalTime;
 		public ITimer timer;
 
 		public Func<TransitionAfterContinuous<TStateId>, bool> condition;
@@ -19,22 +19,22 @@ namespace UnityHFSM
 		/// <summary>
 		/// Initialises a new instance of the TransitionAfterContinuous class.
 		/// </summary>
-		/// <param name="delay">The amount of time that must elapse with the <c>to</c> being true for the transition to <c>to</c> happen </param>
+		/// <param name="conditionTotalTime">The amount of time that must elapse with the <c>to</c> being true for the transition to <c>to</c> happen </param>
 		/// <param name="condition">A function that returns true if the state machine
 		/// 	should transition to the <c>to</c> state.
-		/// 	It is only called every frame, but the transition will occur only if the condition is true for the amount of continuous amount of time, determined by <c>delay</c> .</param>
+		/// 	It is only called every frame, but the transition will occur only if the condition is true for the amount of continuous amount of time, determined by <c>conditionTotalTime</c> .</param>
 		/// <inheritdoc cref="Transition{TStateId}(TStateId, TStateId, Func{Transition{TStateId}, bool},
 		/// 	Action{Transition{TStateId}}, Action{Transition{TStateId}}, bool)" />
 		public TransitionAfterContinuous(
 				TStateId from,
 				TStateId to,
-				float delay,
+				float conditionTotalTime,
 				Func<TransitionAfterContinuous<TStateId>, bool> condition = null,
 				Action<TransitionAfterContinuous<TStateId>> onTransition = null,
 				Action<TransitionAfterContinuous<TStateId>> afterTransition = null,
 				bool forceInstantly = false) : base(from, to, forceInstantly)
 		{
-			this.delay = delay;
+			this.conditionTotalTime = conditionTotalTime;
 			this.condition = condition;
 			this.beforeTransition = onTransition;
 			this.afterTransition = afterTransition;
@@ -50,11 +50,11 @@ namespace UnityHFSM
 		{
 			// if no condition is provided, the state will auto transition after the delay amount of time
 			if (condition == null)
-				return timer.Elapsed > delay;
+				return timer.Elapsed > conditionTotalTime;
 
 			// if a condition is provided, it will be tested every frame, and the transition should occur when delay amount of time has elapsed
 			if (condition(this))
-				return timer.Elapsed > delay;
+				return timer.Elapsed > conditionTotalTime;
 
 			// if the condition is false, the timer will reset, restarting the whole process
 			timer.Reset();
@@ -72,14 +72,14 @@ namespace UnityHFSM
 		public TransitionAfterContinuous(
 			string @from,
 			string to,
-			float delay,
+			float conditionTotalTime,
 			Func<TransitionAfterContinuous<string>, bool> condition = null,
 			Action<TransitionAfterContinuous<string>> onTransition = null,
 			Action<TransitionAfterContinuous<string>> afterTransition = null,
 			bool forceInstantly = false) : base(
 				@from,
 				to,
-				delay,
+				conditionTotalTime,
 				condition,
 				onTransition: onTransition,
 				afterTransition: afterTransition,

--- a/src/Transitions/TransitionAfterContinuous.cs.meta
+++ b/src/Transitions/TransitionAfterContinuous.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6057fbd6901c58349bde20d751019cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A new transition class has been added to the project: `TransitionAfterContinous`

this transition verification process will check the specified condition, and for the transition to occur, the return value of the `condition` property  has to remain true for a period of time, determined by the `conditionTotalTime` property.

This allows for continous check of the condition, as a sort of memory keeping.

This feature is useful for enemy sight, for example, if an enemy has a Patrol and a Chase state, and it will transition from Chase to Patrol when looses sight of player, the `TransitionAfterContinous` transition can be used to transition to the Patrol state only if the enemy haven't seen the player in 5 seconds, and if it loses sight of the player, but if it spots him again in a period of time shorter than 5 seconds, it will keep chasing him down, without executiing the transition.
